### PR TITLE
Fix implementation

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -856,7 +856,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         self._entries = Self._new_entries(self._reserved)
 
     fn setdefault(
-        inout self: Reference[Self, _, _], key: K, owned default: V
+        self: Reference[Self, True, _], key: K, owned default: V
     ) raises -> Reference[V, self.is_mutable, self.lifetime]:
         """Get a value from the dictionary by key, or set it to a default if it doesn't exist.
 

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -528,9 +528,9 @@ fn test_dict_setdefault() raises:
     var some_dict = Dict[String, Int]()
     some_dict["key1"] = 1
     some_dict["key2"] = 2
-    assert_equal(some_dict.setdefault("key1", 0), 1)
-    assert_equal(some_dict.setdefault("key2", 0), 2)
-    assert_equal(some_dict.setdefault("not_key", 0), 0)
+    assert_equal(some_dict.setdefault("key1", 0)[], 1)
+    assert_equal(some_dict.setdefault("key2", 0)[], 2)
+    assert_equal(some_dict.setdefault("not_key", 0)[], 0)
     assert_equal(some_dict["not_key"], 0)
 
 


### PR DESCRIPTION
Fix an issue in my `Dict.setdefault()` implementation:
```
Included from /home/msaelices/src/mojo/stdlib/src/collections/__init__.mojo:1:                                                                                                                     
/home/msaelices/src/mojo/stdlib/src/collections/dict.mojo:859:15: error: 'self' argument must have type 'Dict[K, V]', but actually has type 'Reference[Dict[K, V], is_mutable, lifetime, 0]'       
        inout self: Reference[Self, _, _], key: K, owned default: V                                                                                                                                
              ^     ~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                          
/home/msaelices/.modular/pkg/packages.modular.com_nightly_mojo/bin/mojo: error: could not generate documentation       
```
Fix by @gabrieldemarmiesse. Thanks for it.