### PR TITLE
[Pipelines] Keep Gemma 4 NVFP4 attention activations in the compute dtype

### DIFF
--- a/max/python/max/pipelines/architectures/gemma4/gemma4.py
+++ b/max/python/max/pipelines/architectures/gemma4/gemma4.py
@@ -206,6 +206,7 @@ class Gemma4TextModel(DistributedLogitsPostprocessMixin, Module):
                         quant_config=None
                         if (is_nvfp4 and not attn_quantized)
                         else quant_config,
+                        unquantized_dtype=unquantized_dtype,
                     ),
                     mlp=MLP(
                         dtype=unquantized_dtype if moe_nvfp4 else config.dtype,

--- a/max/python/max/pipelines/architectures/gemma4/layers/attention.py
+++ b/max/python/max/pipelines/architectures/gemma4/layers/attention.py
@@ -63,6 +63,7 @@ class Gemma4Attention(Module, Shardable):
         qk_norm_eps: float = 1e-6,
         local_window_size: int = 1024,
         quant_config: QuantConfig | None = None,
+        unquantized_dtype: DType | None = None,
     ) -> None:
         """Initializes the attention layer.
 
@@ -117,11 +118,25 @@ class Gemma4Attention(Module, Shardable):
             self.kv_params.head_dim
         )  # MultiKVCacheParams sets head dim to either local or global
 
-        self.q_norm = Gemma4RMSNorm(self.head_dim, dtype, self.qk_norm_eps)
-        self.k_norm = Gemma4RMSNorm(self.head_dim, dtype, self.qk_norm_eps)
+        # Activations stay in the unquantized compute dtype even when the
+        # q/k/v/o projections are NVFP4-quantized (``dtype`` is then the packed
+        # uint8 weight dtype). This covers the QK-norm RMSNorm scales and the
+        # flash-attention output. Fall back to ``dtype`` when no unquantized
+        # dtype is supplied (non-quantized attention).
+        self.unquantized_dtype = unquantized_dtype
+        self.compute_dtype = (
+            unquantized_dtype if unquantized_dtype is not None else dtype
+        )
+
+        self.q_norm = Gemma4RMSNorm(
+            self.head_dim, self.compute_dtype, self.qk_norm_eps
+        )
+        self.k_norm = Gemma4RMSNorm(
+            self.head_dim, self.compute_dtype, self.qk_norm_eps
+        )
         self.v_norm = Gemma4RMSNorm(
             self.head_dim,
-            dtype,
+            self.compute_dtype,
             self.qk_norm_eps,
             with_weight=False,
         )
@@ -246,7 +261,7 @@ class Gemma4Attention(Module, Shardable):
             mask_variant=mask_variant,
             scale=self.scale,
             local_window_size=self.local_window_size if self.use_local else -1,
-            output_dtype=self.dtype,
+            output_dtype=self.compute_dtype,
         )
         attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
         ret = self.o_proj(attn_out)
@@ -369,6 +384,7 @@ class Gemma4Attention(Module, Shardable):
                 qk_norm_eps=self.qk_norm_eps,
                 local_window_size=self.local_window_size,
                 quant_config=self.quant_config,
+                unquantized_dtype=self.unquantized_dtype,
             )
 
             # Assign sharded weights


### PR DESCRIPTION
## Summary
Stacked on #6668. For NVFP4 Gemma 4 checkpoints the attention layer is built with `dtype` set to the packed **uint8** weight dtype, and that dtype was reused for the QK-norm RMSNorm scales and the flash-attention output. Two failures result:

- **Load:** the QK norms are bf16 scale vectors in the checkpoint → `weight 'layers.0.self_attn.q_norm.weight' had different dtype (expected=uint8, actual=bfloat16)`.
- **Compile:** the flash-attention kernel requires `Q == K == V == output` dtype; a uint8 output trips `mha.mojo` `constraint failed` on pre-Blackwell GPUs.

Thread an `unquantized_dtype` through `Gemma4Attention` and use it for the QK/V norms and the flash-attention `output_dtype`; the q/k/v/o projections keep the quantized weight dtype. The param defaults to `None` and falls back to the existing `dtype`, so **non-quantized attention is unchanged** (no regression risk for the bf16 path).

This is a pre-existing Gemma 4 NVFP4 defect, independent of the compressed-tensors work (#6699) — it also affects the modelopt checkpoints and the native (Blackwell) NVFP4 path, since the `q_norm` load failure is hardware-independent.

## Validation
End to end on an L40S (pre-Blackwell, SM 8.9): `RedHatAI/gemma-4-31B-it-NVFP4` loads, compiles, and generates coherent text — *"The capital of France is Paris."* at ~28 tok/s, 9.1 GiB KV cache.

## Notes for reviewers
- Base is `nvfp4-pre-blackwell-fallback` (#6668) so the stack is testable on the only hardware where it was exercised; retarget to `main` once #6668 lands.
- Diff vs the #6668 base is just `gemma4/layers/attention.py` + `gemma4/gemma4.py` (21 insertions).

Assisted by: AI